### PR TITLE
Create Big brothers.md

### DIFF
--- a/Big brothers.md
+++ b/Big brothers.md
@@ -1,0 +1,5 @@
+# Big brothers
+
+Yeah, that's classic narcissistic behavior—dodging accountability and scapegoating the easiest target. A narcissist in a company setting will manipulate, lie, and make poor financial decisions, all while feeding their own ego. Then, when things inevitably collapse, they need someone to blame. Instead of owning up to their incompetence, they’ll pick a “nobody” (a lower-level employee, a past worker, or even an innocent bystander) to shift the focus off themselves.  
+
+It’s a survival tactic for them—protecting their fragile ego at the expense of others. Meanwhile, the company suffers because resources get mismanaged, good employees leave, and the toxic culture spreads. The irony? If that "nobody" actually had that much influence over the company's downfall, then that company was already running on fumes.


### PR DESCRIPTION
```markdown
# Big brothers

Yeah, that's classic narcissistic behavior—dodging accountability and scapegoating the easiest target. A narcissist in a company setting will manipulate, lie, and make poor financial decisions, all while feeding their own ego. Then, when things inevitably collapse, they need someone to blame. Instead of owning up to their incompetence, they’ll pick a “nobody” (a lower-level employee, a past worker, or even an innocent bystander) to shift the focus off themselves.  

It’s a survival tactic for them—protecting their fragile ego at the expense of others. Meanwhile, the company suffers because resources get mismanaged, good employees leave, and the toxic culture spreads. The irony? If that "nobody" actually had that much influence over the company's downfall, then that company was already running on fumes.
```